### PR TITLE
Remove redundant variable init and base64 decoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,62 +12,10 @@
                 processImage();
             }
 
-            function base64ArrayBuffer(bytes) {
-                var base64    = ''
-                var encodings = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-
-                var byteLength    = bytes.byteLength
-                var byteRemainder = byteLength % 3
-                var mainLength    = byteLength - byteRemainder
-
-                var a, b, c, d
-                var chunk
-
-                // Main loop deals with bytes in chunks of 3
-                for (var i = 0; i < mainLength; i = i + 3) {
-                    // Combine the three bytes into a single integer
-                    chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2]
-
-                    // Use bitmasks to extract 6-bit segments from the triplet
-                    a = (chunk & 16515072) >> 18 // 16515072 = (2^6 - 1) << 18
-                    b = (chunk & 258048)   >> 12 // 258048   = (2^6 - 1) << 12
-                    c = (chunk & 4032)     >>  6 // 4032     = (2^6 - 1) << 6
-                    d = chunk & 63               // 63       = 2^6 - 1
-
-                    // Convert the raw binary segments to the appropriate ASCII encoding
-                    base64 += encodings[a] + encodings[b] + encodings[c] + encodings[d]
-                }
-
-                // Deal with the remaining bytes and padding
-                if (byteRemainder == 1) {
-                    chunk = bytes[mainLength]
-
-                    a = (chunk & 252) >> 2 // 252 = (2^6 - 1) << 2
-
-                    // Set the 4 least significant bits to zero
-                    b = (chunk & 3)   << 4 // 3   = 2^2 - 1
-
-                    base64 += encodings[a] + encodings[b] + '=='
-                } else if (byteRemainder == 2) {
-                    chunk = (bytes[mainLength] << 8) | bytes[mainLength + 1]
-
-                    a = (chunk & 64512) >> 10 // 64512 = (2^6 - 1) << 10
-                    b = (chunk & 1008)  >>  4 // 1008  = (2^6 - 1) << 4
-
-                    // Set the 2 least significant bits to zero
-                    c = (chunk & 15)    <<  2 // 15    = 2^4 - 1
-
-                    base64 += encodings[a] + encodings[b] + encodings[c] + '='
-                }
-
-                return base64
-            }
-
             function imageProcessed(pointer, length) {
                 let resultBytes = memoryBytes.slice(pointer, pointer + length);
-                let b64 = base64ArrayBuffer(resultBytes);
-                let src = 'data:image/jpeg;base64,' + b64;
-                document.getElementById('out').src = src;
+                let blob = new Blob([resultBytes], {'type': 'image/jpeg'});
+                document.getElementById('out').src = URL.createObjectURL(blob);
             }
 
             let openFile = function(event) {

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
         <script src="wasm_exec.js"></script>
         <script>
             const go = new Go();
-            const wasmMemory = new WebAssembly.Memory({initial: 512});
-            let memoryBytes = new Uint8Array(wasmMemory.buffer)
+            let memoryBytes;
             let mod, inst, bytes;
 
             function gotMem(pointer) {


### PR DESCRIPTION
Thanks for sharing the tip. Thought of giving back by sending a PR !

I have updated my codebase to the new approach now - https://github.com/agnivade/shimmer !

EDIT: Also found out a way to avoid the base64 decoding on the way out :wink: 